### PR TITLE
fix(plugins/homepageSwitcher): closing current tab if none found

### DIFF
--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -85,6 +85,9 @@ export default defineBackground(() => {
       const toTab = await browser.tabs.query({ url: msg.url });
       if (toTab.length > 0) {
         browser.tabs.update(toTab[0].id, { active: true });
+        if (msg.closeIfFound && sender.tab?.id && sender.tab.id !== toTab[0].id) {
+          browser.tabs.remove(sender.tab.id);
+        }
       } else if (sender.tab?.id) {
         browser.tabs.update(sender.tab.id, { url: msg.url });
       }

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -79,8 +79,6 @@ export default defineBackground(() => {
       resetSettings();
     } else if (msg.type === "updateIcon") {
       updateIcon();
-    } else if (msg.type === "closeTab" && sender.tab?.id) {
-      browser.tabs.remove(sender.tab.id);
     } else if (msg.type === "toTab") {
       const toTab = await browser.tabs.query({ url: msg.url });
       if (toTab.length > 0) {

--- a/src/entrypoints/plugins/homepageSwitcher/index.ts
+++ b/src/entrypoints/plugins/homepageSwitcher/index.ts
@@ -41,8 +41,7 @@ export default new Plugin<Settings>(
 
           if (logos) {
             const tabUrl = logos[0].href;
-            if (closeCurrentTab.toggle) sendMessage({ type: "closeTab" });
-            sendMessage({ type: "toTab", url: tabUrl });
+            sendMessage({ type: "toTab", url: tabUrl, closeIfFound: closeCurrentTab.toggle });
           }
         },
         {

--- a/src/utils/storage/types.ts
+++ b/src/utils/storage/types.ts
@@ -1,7 +1,6 @@
 export type BackgroundMessage =
   | { type: "resetSettings" }
   | { type: "updateIcon" }
-  | { type: "closeTab" }
   | { type: "toTab"; url: string, closeIfFound: boolean };
 
 // global

--- a/src/utils/storage/types.ts
+++ b/src/utils/storage/types.ts
@@ -2,7 +2,7 @@ export type BackgroundMessage =
   | { type: "resetSettings" }
   | { type: "updateIcon" }
   | { type: "closeTab" }
-  | { type: "toTab"; url: string };
+  | { type: "toTab"; url: string, closeIfFound: boolean };
 
 // global
 export interface SettingsV1 {


### PR DESCRIPTION
… no homepage was found

Currently, if the "Close current tab" setting is enabled in the Homepage Switcher plugin, the webpage would close regardless of whether a valid schooltape homepage tab was found. The result is if the user clicks on the homepage icon and there isn't an open homepage tab, the current tab would just close.

This behaviour arises from this code:
```ts
if (closeCurrentTab.toggle) sendMessage({ type: "closeTab" });
```
Where the code sends a signal to close the current tab regardless of the result of the proceeding `toTab` call.

To resolve this issue, this PR adds an additional property to the `toTab` call called `closeIfFound`, and modifies the background logic to close the tab only if the user has successfully switched tabs.